### PR TITLE
fix: correct hero backdrop z-index

### DIFF
--- a/apps/frontend/styles/landing-page.css
+++ b/apps/frontend/styles/landing-page.css
@@ -290,6 +290,7 @@
   /* ------ Modal ------ */
   .modal {
     position: fixed;
+    z-index: 10;
     inset: 0;
     background: rgba(0, 0, 0, 0.65);
     display: none;


### PR DESCRIPTION
This PR corrects the backdrop animation for the hero image.

<img width="981" height="690" alt="image" src="https://github.com/user-attachments/assets/1e8fbb19-d2ce-438a-b551-8e3ba8bbc2d1" />
