### PR TITLE
feat: implement admin login endpoint integration with improved UX

### DIFF
--- a/apps/frontend/js/admin-auth.js
+++ b/apps/frontend/js/admin-auth.js
@@ -1,9 +1,74 @@
-userPassword = document.getElementById("auth-password");
+const loginForm = document.getElementById("login-form");
+const loginErrorMsg = document.getElementById("login-error-msg");
+const loginPassword = document.getElementById("auth-password");
+const loginEmail = document.getElementById("login-email");
+const toggleBtn = document.getElementById("toggle-password");
 
-const displayPassword = () => {
-  if (userPassword.type === "password") {
-    userPassword.type = "text";
-  } else {
-    userPassword.type = "password";
-  }
+const apiBase = (loginForm.dataset.apiBase || "").replace(/\/$/, "");
+const loginEndpoint = apiBase
+  ? `${apiBase}/auth/admin/login`
+  : "/api/auth/admin/login";
+
+// Password visibility toggle
+toggleBtn.addEventListener("click", () => {
+  const isVisible = loginPassword.type === "text";
+  loginPassword.type = isVisible ? "password" : "text";
+  toggleBtn.classList.toggle("is-visible", !isVisible);
+  toggleBtn.setAttribute(
+    "aria-label",
+    isVisible ? "Show password" : "Hide password",
+  );
+  toggleBtn.setAttribute("aria-pressed", String(!isVisible));
+});
+
+// Error handling
+const showError = (message) => {
+  loginErrorMsg.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="12" y1="8" x2="12" y2="12"/>
+      <line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+    <span>${message}</span>
+  `;
+  loginErrorMsg.classList.add("is-visible");
 };
+
+const clearError = () => {
+  loginErrorMsg.classList.remove("is-visible");
+  loginErrorMsg.innerHTML = "";
+};
+
+// Login form submission
+loginForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  clearError();
+
+  loginEmail.value = loginEmail.value.trim();
+  loginPassword.value = loginPassword.value.trim();
+
+  try {
+    const response = await fetch(loginEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: loginEmail.value,
+        password: loginPassword.value,
+      }),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok || !result.success) {
+      showError(result.error || "Invalid email or password.");
+      return;
+    }
+
+    localStorage.setItem("access_token", result.data.token.access_token);
+    localStorage.setItem("refresh_token", result.data.token.refresh_token);
+
+    window.location.href = "admin-nomination.html";
+  } catch (error) {
+    showError("Something went wrong. Please try again.");
+  }
+});

--- a/apps/frontend/pages/admin-login.html
+++ b/apps/frontend/pages/admin-login.html
@@ -30,7 +30,11 @@
           <p>Sign in to your Luminary account to continue.</p>
         </header>
 
-        <form class="auth-form" id="login-form">
+        <form
+          class="auth-form"
+          id="login-form"
+          data-api-base="http://127.0.0.1:5000/api"
+        >
           <div class="form-group">
             <label for="login-email">Email address</label>
             <input
@@ -44,21 +48,63 @@
           </div>
 
           <div class="form-group">
-            <label for="login-password">Password</label>
-            <input
-              type="password"
-              id="auth-password"
-              name="password"
-              placeholder="Enter your password"
-              autocomplete="current-password"
-              required
-            />
-            <span class="password-toggle-label flex gap-3">
+            <label for="auth-password">Password</label>
+            <div class="password-field">
               <input
-                class="password-toggle"
-                type="checkbox"
-                onclick="displayPassword()"
-              />Show Password</span>
+                type="password"
+                id="auth-password"
+                name="password"
+                placeholder="Enter your password"
+                autocomplete="current-password"
+                required
+              />
+              <button
+                type="button"
+                class="password-toggle-btn"
+                id="toggle-password"
+                aria-label="Show password"
+                aria-pressed="false"
+              >
+                <svg
+                  class="icon-eye"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <svg
+                  class="icon-eye-off"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"
+                  />
+                  <path
+                    d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"
+                  />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              </button>
+            </div>
+            <span id="login-error-msg" role="alert" aria-live="polite"></span>
           </div>
           <button type="submit" class="auth-submit-btn">Sign In</button>
         </form>

--- a/apps/frontend/styles/auth.css
+++ b/apps/frontend/styles/auth.css
@@ -137,6 +137,83 @@
   outline-offset: 2px;
 }
 
+.password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-field input {
+  padding-right: 2.75rem;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: var(--space-1);
+  color: var(--color-text-400);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s ease;
+  line-height: 0;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-heading-500);
+}
+
+.password-toggle-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.password-toggle-btn .icon-eye-off {
+  display: none;
+}
+
+.password-toggle-btn.is-visible .icon-eye {
+  display: none;
+}
+
+.password-toggle-btn.is-visible .icon-eye-off {
+  display: block;
+}
+
+/* Error message */
+#login-error-msg {
+  display: none;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--destructive-foreground);
+  background-color: var(--destructive);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  animation: slideDown 0.2s ease;
+}
+
+#login-error-msg.is-visible {
+  display: flex;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .auth-submit-btn {
   width: 100%;
   padding: var(--space-4);


### PR DESCRIPTION
This PR connects the admin login page to the backend authentication endpoint and improves the UX of the password toggle and error message on the login form.
Summary: 
- Login endpoint: has POST `/api/auth/admin/login` wired up, stores `access_token` + `refresh_token` in localStorage on success, redirects admin to admin dashboard.
- API URL: reads from `data-api-base` on the form
- Password toggle: replaced checkbox + onclick with a proper icon button (eye/eye-off SVGs, aria-pressed, aria-label)
- Error message: uses existing design tokens, slide-in animation, and `aria-live="polite"` for screen readers

Here is a screenshot:
<img width="960" height="924" alt="Screenshot 2026-03-20 173621" src="https://github.com/user-attachments/assets/c6d4d453-6b9b-4056-9719-bcf6f7f643df" />


#62 