### PR TITLE
Add consent request page and form functionality with styles

### DIFF
--- a/apps/frontend/js/main/consent-form.js
+++ b/apps/frontend/js/main/consent-form.js
@@ -1,0 +1,345 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("nominationForm");
+
+  if (!form) {
+    return;
+  }
+
+  const toggleButtons = form.querySelectorAll("[data-form-toggle]");
+  const panels = form.querySelectorAll("[data-form-panel]");
+  const sectionToggles = form.querySelectorAll(".section-toggle");
+  const addLinkButtons = form.querySelectorAll("[data-add-link]");
+  const apiBase = (form.dataset.apiBase || "").replace(/\/$/, "");
+  const endpoint = apiBase ? `${apiBase}/nomination` : "/api/nomination";
+  let edit = false;
+
+  const setStatus = (panel, message, type = "info") => {
+    const status = panel.querySelector(".form-status");
+
+    if (!status) {
+      return;
+    }
+
+    status.textContent = message;
+    status.classList.toggle("is-error", type === "error");
+    status.classList.toggle("is-success", type === "success");
+  };
+
+  const clearStatus = () => {
+    panels.forEach((panel) => {
+      const status = panel.querySelector(".form-status");
+
+      if (!status) {
+        return;
+      }
+
+      status.textContent = "";
+      status.classList.remove("is-error", "is-success");
+    });
+  };
+
+  const splitName = (value) => {
+    const parts = value.trim().split(/\s+/).filter(Boolean);
+
+    return {
+      firstName: parts[0] || "",
+      lastName: parts.slice(1).join(" "),
+    };
+  };
+
+  const getValue = (panel, selector) => {
+    const input = panel.querySelector(selector);
+    return input ? input.value.trim() : "";
+  };
+
+  const getLinks = (panel, groupName) =>
+    Array.from(panel.querySelectorAll(`[data-link-group="${groupName}"] input`))
+      .map((input) => input.value.trim())
+      .filter(Boolean);
+
+  const setActivePanel = (panelName) => {
+    clearStatus();
+
+    toggleButtons.forEach((button) => {
+      const isActive = button.dataset.formToggle === panelName;
+      button.classList.toggle("is-active", isActive);
+      button.setAttribute("aria-selected", String(isActive));
+      button.tabIndex = isActive ? 0 : -1;
+    });
+
+    panels.forEach((panel) => {
+      const isActive = panel.dataset.formPanel === panelName;
+      panel.hidden = !isActive;
+      panel.setAttribute("aria-hidden", String(!isActive));
+      panel.classList.toggle("is-active", isActive);
+
+      panel
+        .querySelectorAll("input, textarea, select, button")
+        .forEach((field) => {
+          if (!edit) {
+            field.disabled = !isActive;
+          }
+        });
+    });
+  };
+
+  const initSectionToggles = () => {
+    sectionToggles.forEach((toggle) => {
+      const section = toggle.closest(".form-section");
+      const body = section?.querySelector(".section-body");
+
+      if (!section || !body) {
+        return;
+      }
+
+      body.hidden = false;
+      toggle.setAttribute("aria-expanded", "true");
+
+      toggle.addEventListener("click", () => {
+        const isCollapsed = section.classList.toggle("is-collapsed");
+        body.hidden = isCollapsed;
+        toggle.setAttribute("aria-expanded", String(!isCollapsed));
+      });
+    });
+  };
+
+  const initAddLinks = () => {
+    addLinkButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const groupName = button.dataset.addLink;
+        const panel = button.closest(".form-panel");
+        const group = panel?.querySelector(`[data-link-group="${groupName}"]`);
+
+        if (!group) {
+          return;
+        }
+
+        const inputName = group.dataset.inputName || groupName;
+        const placeholder = group.dataset.placeholder || "https://";
+        const inputCount = group.querySelectorAll("input").length;
+        const nextIndex = inputCount + 1;
+
+        const newInput = document.createElement("input");
+        newInput.type = "url";
+        newInput.placeholder = placeholder;
+        newInput.id = `${inputName}${nextIndex}`;
+        newInput.name = `${inputName}${nextIndex}`;
+        newInput.setAttribute("aria-label", `${groupName} link ${nextIndex}`);
+
+        group.appendChild(newInput);
+      });
+    });
+  };
+
+  const initImagePreview = () => {
+    const uploads = form.querySelectorAll(".profile-upload");
+
+    uploads.forEach((upload) => {
+      const input = upload.querySelector('input[type="file"]');
+      const preview = upload.querySelector(".profile-upload__preview");
+
+      if (!input || !preview) {
+        return;
+      }
+
+      input.addEventListener("change", (event) => {
+        const file = event.target.files && event.target.files[0];
+
+        if (!file) {
+          preview.style.backgroundImage = "";
+          preview.classList.remove("has-image");
+          return;
+        }
+
+        if (!file.type.startsWith("image/")) {
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (loadEvent) => {
+          preview.style.backgroundImage = `url("${loadEvent.target.result}")`;
+          preview.classList.add("has-image");
+        };
+
+        reader.readAsDataURL(file);
+      });
+    });
+  };
+
+  const initEditButton = () => {
+    const editBtn = document.getElementById("edit-btn");
+
+    if (!editBtn) {
+      return;
+    }
+
+    editBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      edit = true;
+
+      const activePanel = form.querySelector(".form-panel.is-active") || form;
+      const nominatorFields = [
+        "nominatorName",
+        "nominatorEmail",
+        "relationship",
+      ];
+
+      activePanel
+        .querySelectorAll("input, textarea, select, button")
+        .forEach((field) => {
+          if (
+            !nominatorFields.includes(field.id) &&
+            !field.classList.contains("rescind") &&
+            !field.classList.contains("consent")
+          ) {
+            field.disabled = false;
+            field.removeAttribute("aria-disabled");
+          }
+        });
+
+      // Reveal hidden labels (like "Upload image" buttons)
+      activePanel.querySelectorAll("label[hidden]").forEach((label) => {
+        label.removeAttribute("hidden");
+      });
+      activePanel
+        .querySelectorAll(".profile-upload__hint[hidden]")
+        .forEach((hint) => {
+          hint.removeAttribute("hidden");
+        });
+
+      editBtn.style.display = "none";
+      edit = true;
+    });
+  };
+
+  const buildPayload = (panel) => {
+    const isSelfSubmission = panel.dataset.formPanel === "self-submission";
+    const nomineeName = getValue(
+      panel,
+      isSelfSubmission ? "#self-nomineeName" : "#nomineeName",
+    );
+    const nomineeEmail = getValue(
+      panel,
+      isSelfSubmission ? "#self-nomineeEmail" : "#nomineeEmail",
+    );
+    const fieldOfWork = getValue(
+      panel,
+      isSelfSubmission ? "#self-fieldOfWork" : "#fieldOfWork",
+    );
+    const region = getValue(
+      panel,
+      isSelfSubmission ? "#self-region" : "#region",
+    );
+    const description = getValue(
+      panel,
+      isSelfSubmission ? "#self-impactDescription" : "#impactDescription",
+    );
+
+    const { firstName: nominee_first_name, lastName: nominee_last_name } =
+      splitName(nomineeName);
+
+    const supportingGroup = isSelfSubmission ? "self-supporting" : "supporting";
+    const socialGroup = isSelfSubmission ? "self-social" : "social";
+
+    const payload = {
+      is_self_submission: isSelfSubmission,
+      nominee_first_name,
+      nominee_last_name,
+      nominee_email: nomineeEmail,
+      nominee_country: region,
+      nominee_field: fieldOfWork,
+      nominee_organization: "",
+      evidence_urls: getLinks(panel, socialGroup),
+      supporting_urls: getLinks(panel, supportingGroup),
+      description,
+    };
+
+    if (!isSelfSubmission) {
+      const nominatorName = getValue(panel, "#nominatorName");
+      const nominatorEmail = getValue(panel, "#nominatorEmail");
+      const relationship = getValue(panel, "#relationship");
+      const { firstName: nominator_first_name, lastName: nominator_last_name } =
+        splitName(nominatorName);
+
+      payload.nominator_first_name = nominator_first_name;
+      payload.nominator_last_name = nominator_last_name;
+      payload.nominator_email = nominatorEmail;
+      payload.relationship_to_nominee = relationship;
+    }
+
+    return payload;
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    clearStatus();
+
+    const activePanel = form.querySelector("[data-form-panel].is-active");
+
+    if (!activePanel) {
+      return;
+    }
+
+    const submitButton = activePanel.querySelector(".submit-btn");
+    const originalButtonText = submitButton ? submitButton.textContent : "";
+    const payload = buildPayload(activePanel);
+
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = "Submitting...";
+    }
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json().catch(() => ({}));
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || "Unable to submit nomination.");
+      }
+
+      setStatus(
+        activePanel,
+        "Submission received. We will reach out shortly.",
+        "success",
+      );
+      form.reset();
+      form.querySelectorAll(".profile-upload__preview").forEach((preview) => {
+        preview.style.backgroundImage = "";
+        preview.classList.remove("has-image");
+      });
+    } catch (error) {
+      setStatus(
+        activePanel,
+        error.message || "Something went wrong. Please try again.",
+        "error",
+      );
+    } finally {
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.textContent = originalButtonText || "Submit Nomination";
+      }
+    }
+  };
+
+  toggleButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      //   setActivePanel(button.dataset.formToggle);
+    });
+  });
+
+  form.addEventListener("submit", handleSubmit);
+
+  // editButton.addEventListener("click", () => setActivePanel("nomination"));
+
+  initSectionToggles();
+  initAddLinks();
+  initImagePreview();
+  initEditButton();
+});

--- a/apps/frontend/js/main/consent-form.js
+++ b/apps/frontend/js/main/consent-form.js
@@ -197,10 +197,16 @@ window.addEventListener("DOMContentLoaded", () => {
           }
         });
 
-      // Reveal hidden labels (like "Upload image" buttons)
-      activePanel.querySelectorAll("label[hidden]").forEach((label) => {
-        label.removeAttribute("hidden");
-      });
+      // Reveal hidden labels
+      activePanel
+        .querySelectorAll("label[hidden], .upload-btn")
+        .forEach((label) => {
+          label.removeAttribute("hidden");
+          label.removeAttribute("aria-disabled");
+          if (label.classList.contains("upload-btn")) {
+            label.style.display = "inline-flex";
+          }
+        });
       activePanel
         .querySelectorAll(".profile-upload__hint[hidden]")
         .forEach((hint) => {

--- a/apps/frontend/pages/main/consent-request.html
+++ b/apps/frontend/pages/main/consent-request.html
@@ -65,71 +65,18 @@
           aria-labelledby="nomination-tab"
         >
           <section class="form-section">
-            <div class="section-header">
-              <h2 class="section-title">Your Details (Nominator)</h2>
-              <button
-                type="button"
-                class="section-toggle"
-                aria-expanded="true"
-                aria-controls="nominator-details"
-              >
-                <span class="section-caret" aria-hidden="true"></span>
-              </button>
-            </div>
-            <div class="section-body" id="nominator-details">
-              <div class="field-grid two-col">
-                <div class="field">
-                  <label for="nominatorName"
-                    >Full name <span class="required">*</span></label
-                  >
-                  <input
-                    id="nominatorName"
-                    name="nominatorName"
-                    type="text"
-                    placeholder="Full name"
-                    required
-                  />
-                </div>
-                <div class="field">
-                  <label for="nominatorEmail"
-                    >Email address <span class="required">*</span></label
-                  >
-                  <input
-                    id="nominatorEmail"
-                    name="nominatorEmail"
-                    type="email"
-                    placeholder="name@company.com"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="field">
-                <label for="relationship"
-                  >Relationship to nominee
-                  <span class="required">*</span></label
+            <div class="header-1">
+              <div class="section-header">
+                <h2 class="section-title">Nominee Information</h2>
+                <button
+                  type="button"
+                  class="section-toggle"
+                  aria-expanded="true"
+                  aria-controls="nominee-details"
                 >
-                <input
-                  id="relationship"
-                  name="relationship"
-                  type="text"
-                  placeholder="e.g. Colleague"
-                  required
-                />
+                  <span class="section-caret" aria-hidden="true"></span>
+                </button>
               </div>
-            </div>
-          </section>
-
-          <section class="form-section">
-            <div class="section-header">
-              <h2 class="section-title">Nominee Information</h2>
-              <button
-                type="button"
-                class="section-toggle"
-                aria-expanded="true"
-                aria-controls="nominee-details"
-              >
-                <span class="section-caret" aria-hidden="true"></span>
-              </button>
               <p>
                 The personal and professional details submitted for your
                 profile.
@@ -217,34 +164,43 @@
                 <textarea
                   id="impactDescription"
                   name="impactDescription"
-                  value="Describe the nominee's impact, contributions, and why they should be featured..."
                   required
                   disabled
                   aria-disabled="true"
-                ></textarea>
+                >
+Led multiple high-impact projects bridging technology and social change.</textarea
+                >
               </div>
             </div>
           </section>
 
           <section class="form-section">
-            <div class="section-header">
-              <h2 class="section-title">Work &amp; Media</h2>
-              <button
-                type="button"
-                class="section-toggle"
-                aria-expanded="true"
-                aria-controls="nomination-work-media"
-              >
-                <span class="section-caret" aria-hidden="true"></span>
-              </button>
+            <div class="header-1">
+              <div class="section-header">
+                <h2 class="section-title">Profile Photo</h2>
+                <button
+                  type="button"
+                  class="section-toggle"
+                  aria-expanded="true"
+                  aria-controls="nomination-work-media"
+                >
+                  <span class="section-caret" aria-hidden="true"></span>
+                </button>
+              </div>
+              The image that will appear on the public directory.
             </div>
             <div class="section-body" id="nomination-work-media">
               <div class="field">
                 <label for="profilePhoto"
-                  >Profile Photo <span class="required">*</span></label
+                  >Current Photo <span class="required">*</span></label
                 >
                 <div class="profile-upload">
-                  <div class="profile-upload__preview" aria-hidden="true"></div>
+                  <div class="profile-upload__preview" aria-hidden="true">
+                    <img
+                      src="../../assets/images/profile-image.jpg"
+                      alt="Profile photo preview"
+                    />
+                  </div>
                   <div class="profile-upload__controls">
                     <input
                       id="profilePhoto"
@@ -255,16 +211,45 @@
                       disabled
                       aria-disabled="true"
                     />
-                    <label class="upload-btn" for="profilePhoto"
+                    <label
+                      class="upload-btn"
+                      for="profilePhoto"
+                      aria-disabled="true"
+                      hidden
                       >Upload image</label
                     >
-                    <p class="profile-upload__hint">
+                    <p class="profile-upload__hint" hidden>
                       .jpg, .png or .webp supported (max 5MB)
+                    </p>
+
+                    <p class="profile-upload__hint">
+                      This photo was provided by your nominator
                     </p>
                   </div>
                 </div>
               </div>
+            </div>
+          </section>
 
+          <section class="form-section">
+            <div class="header-1">
+              <div class="section-header">
+                <h2 class="section-title">Evidence &amp; Links</h2>
+                <button
+                  type="button"
+                  class="section-toggle"
+                  aria-expanded="true"
+                  aria-controls="nomination-work-media"
+                >
+                  <span class="section-caret" aria-hidden="true"></span>
+                </button>
+              </div>
+              <p>
+                Achievements and supporting materials provided by your
+                nominator.
+              </p>
+            </div>
+            <div class="section-body" id="nomination-work-media">
               <div class="field">
                 <label for="supportingLink1"
                   >Supporting Links (Articles, Publications, Projects)
@@ -280,20 +265,26 @@
                     id="supportingLink1"
                     name="supportingLink1"
                     type="url"
-                    placeholder="https://"
+                    value="https://example.com/project"
                     required
+                    disabled
+                    aria-disabled="true"
                   />
                   <input
                     id="supportingLink2"
                     name="supportingLink2"
                     type="url"
-                    placeholder="https://"
+                    value="https://example.com/article"
+                    disabled
+                    aria-disabled="true"
                   />
                 </div>
                 <button
                   class="add-link"
                   type="button"
                   data-add-link="supporting"
+                  disabled
+                  aria-disabled="true"
                 >
                   <span aria-hidden="true">+</span> Add another link
                 </button>
@@ -311,28 +302,94 @@
                     id="socialLink1"
                     name="socialLink1"
                     type="url"
-                    placeholder="https://"
+                    value="https://twitter.com/sarah"
+                    disabled
+                    aria-disabled="true"
                   />
                   <input
                     id="socialLink2"
                     name="socialLink2"
                     type="url"
-                    placeholder="https://"
+                    value="https://linkedin.com/in/sarah"
+                    disabled
+                    aria-disabled="true"
                   />
                 </div>
-                <button class="add-link" type="button" data-add-link="social">
+                <button
+                  class="add-link"
+                  type="button"
+                  data-add-link="social"
+                  disabled
+                  aria-disabled="true"
+                >
                   <span aria-hidden="true">+</span> Add another link
                 </button>
               </div>
             </div>
           </section>
 
-          <button class="submit-btn" type="submit">Submit Nomination</button>
+          <section class="form-section">
+            <div class="header-1">
+              <div class="section-header">
+                <h2 class="section-title">Nominator Details (Nominator)</h2>
+                <button
+                  type="button"
+                  class="section-toggle"
+                  aria-expanded="true"
+                  aria-controls="nominator-details"
+                >
+                  <span class="section-caret" aria-hidden="true"></span>
+                </button>
+              </div>
+              <p>Information about the person who submitted this nomination.</p>
+            </div>
+            <div class="section-body" id="nominator-details">
+              <div class="field-grid two-col">
+                <div class="field">
+                  <label for="nominatorName"
+                    >Submitted By <span class="required">*</span></label
+                  >
+                  <input
+                    id="nominatorName"
+                    name="nominatorName"
+                    type="text"
+                    value="Jane Doe"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  />
+                </div>
+                <div class="field">
+                  <label for="relationship"
+                    >Relationship <span class="required">*</span></label
+                  >
+                  <input
+                    id="relationship"
+                    name="relationship"
+                    type="text"
+                    value="Colleague"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <div class="actions flex justify-between" aria-label="actions">
+            <button class="rescind btn">Rescind Consent</button>
+            <div aria-label="edit or give consent" class="consent-actions">
+              <button class="edit btn" id="edit-btn">Edit Form</button>
+              <button class="consent btn">Give Consent</button>
+            </div>
+          </div>
+
           <p class="form-status" role="status" aria-live="polite"></p>
         </div>
       </form>
     </main>
 
-    <script src="../../js/main/nomination.js" defer></script>
+    <script src="../../js/main/consent-form.js" defer></script>
   </body>
 </html>

--- a/apps/frontend/pages/main/consent-request.html
+++ b/apps/frontend/pages/main/consent-request.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../styles/main/base.css" />
+    <link rel="stylesheet" href="../../styles/main/nav.css" />
+    <link rel="stylesheet" href="../../styles/main/nomination.css" />
+    <link rel="stylesheet" href="../../styles/main/consent-request.css" />
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Raleway:wght@300;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="../../assets/images/luminary-green-favicon.ico"
+    />
+    <title>Luminary | Consent Request</title>
+  </head>
+  <body>
+    <header>
+      <nav
+        aria-label="primary navigation"
+        class="header-section__nav flex flex-row justify-center items-center px-4 py-4"
+      >
+        <a href="../../index.html">
+          <picture>
+            <source
+              media="(min-width: 768px)"
+              srcset="../../assets/images/luminary-green-logo.png"
+              type="image/png"
+            />
+            <img
+              src="../../assets/images/luminary-green-logo.png"
+              alt="Luminary Logo"
+              width="150px"
+            />
+          </picture>
+        </a>
+      </nav>
+    </header>
+    <main class="flex flex-col items-center">
+      <div aria-label="main header" class="main-header text-center">
+        <h1>Profile Review &amp; Consent</h1>
+        <p>
+          You have been nominated to be featured in Luminary Women's Directory.
+          Please review the submitted details and provide your consent to
+          publish this profile.
+        </p>
+      </div>
+
+      <form
+        class="nomination-form"
+        id="nominationForm"
+        action=""
+        data-api-base="http://127.0.0.1:5000/api"
+      >
+        <div
+          id="nomination-panel"
+          class="form-panel is-active"
+          data-form-panel="nomination"
+          role="tabpanel"
+          aria-labelledby="nomination-tab"
+        >
+          <section class="form-section">
+            <div class="section-header">
+              <h2 class="section-title">Your Details (Nominator)</h2>
+              <button
+                type="button"
+                class="section-toggle"
+                aria-expanded="true"
+                aria-controls="nominator-details"
+              >
+                <span class="section-caret" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="section-body" id="nominator-details">
+              <div class="field-grid two-col">
+                <div class="field">
+                  <label for="nominatorName"
+                    >Full name <span class="required">*</span></label
+                  >
+                  <input
+                    id="nominatorName"
+                    name="nominatorName"
+                    type="text"
+                    placeholder="Full name"
+                    required
+                  />
+                </div>
+                <div class="field">
+                  <label for="nominatorEmail"
+                    >Email address <span class="required">*</span></label
+                  >
+                  <input
+                    id="nominatorEmail"
+                    name="nominatorEmail"
+                    type="email"
+                    placeholder="name@company.com"
+                    required
+                  />
+                </div>
+              </div>
+              <div class="field">
+                <label for="relationship"
+                  >Relationship to nominee
+                  <span class="required">*</span></label
+                >
+                <input
+                  id="relationship"
+                  name="relationship"
+                  type="text"
+                  placeholder="e.g. Colleague"
+                  required
+                />
+              </div>
+            </div>
+          </section>
+
+          <section class="form-section">
+            <div class="section-header">
+              <h2 class="section-title">Nominee Information</h2>
+              <button
+                type="button"
+                class="section-toggle"
+                aria-expanded="true"
+                aria-controls="nominee-details"
+              >
+                <span class="section-caret" aria-hidden="true"></span>
+              </button>
+              <p>
+                The personal and professional details submitted for your
+                profile.
+              </p>
+            </div>
+            <div class="section-body" id="nominee-details">
+              <div class="field-grid two-col">
+                <div class="field">
+                  <label for="nomineeName"
+                    >Full name <span class="required">*</span></label
+                  >
+                  <input
+                    id="nomineeName"
+                    name="nomineeName"
+                    type="text"
+                    value="Sarah"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  />
+                </div>
+                <div class="field">
+                  <label for="nomineeEmail"
+                    >Email address <span class="required">*</span></label
+                  >
+                  <input
+                    id="nomineeEmail"
+                    name="nomineeEmail"
+                    type="email"
+                    value="sarah.chen@example.com"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  />
+                </div>
+              </div>
+
+              <div class="field-grid two-col">
+                <div class="field">
+                  <label for="fieldOfWork"
+                    >Field of Work <span class="required">*</span></label
+                  >
+                  <select
+                    id="fieldOfWork"
+                    name="fieldOfWork"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  >
+                    <option value="">Select a field</option>
+                    <option>Business &amp; Entrepreneurship</option>
+                    <option>Science &amp; Research</option>
+                    <option selected>Technology &amp; Engineering</option>
+                    <option>Arts &amp; Culture</option>
+                    <option>Activism &amp; Advocacy</option>
+                    <option>Education &amp; Academia</option>
+                    <option>Health &amp; Medicine</option>
+                    <option>Agriculture &amp; Food</option>
+                    <option>Politics &amp; Governance</option>
+                    <option>Sports &amp; Fitness</option>
+                    <option>Media &amp; Journalism</option>
+                    <option>Finance &amp; Economics</option>
+                  </select>
+                </div>
+                <div class="field">
+                  <label for="region"
+                    >Region <span class="required">*</span></label
+                  >
+                  <input
+                    id="region"
+                    name="region"
+                    type="text"
+                    value="Lagos, Nigeria"
+                    required
+                    disabled
+                    aria-disabled="true"
+                  />
+                </div>
+              </div>
+
+              <div class="field">
+                <label for="impactDescription"
+                  >Description of impact <span class="required">*</span></label
+                >
+                <textarea
+                  id="impactDescription"
+                  name="impactDescription"
+                  value="Describe the nominee's impact, contributions, and why they should be featured..."
+                  required
+                  disabled
+                  aria-disabled="true"
+                ></textarea>
+              </div>
+            </div>
+          </section>
+
+          <section class="form-section">
+            <div class="section-header">
+              <h2 class="section-title">Work &amp; Media</h2>
+              <button
+                type="button"
+                class="section-toggle"
+                aria-expanded="true"
+                aria-controls="nomination-work-media"
+              >
+                <span class="section-caret" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="section-body" id="nomination-work-media">
+              <div class="field">
+                <label for="profilePhoto"
+                  >Profile Photo <span class="required">*</span></label
+                >
+                <div class="profile-upload">
+                  <div class="profile-upload__preview" aria-hidden="true"></div>
+                  <div class="profile-upload__controls">
+                    <input
+                      id="profilePhoto"
+                      name="profilePhoto"
+                      type="file"
+                      accept=".jpg,.jpeg,.png,.webp"
+                      required
+                      disabled
+                      aria-disabled="true"
+                    />
+                    <label class="upload-btn" for="profilePhoto"
+                      >Upload image</label
+                    >
+                    <p class="profile-upload__hint">
+                      .jpg, .png or .webp supported (max 5MB)
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div class="field">
+                <label for="supportingLink1"
+                  >Supporting Links (Articles, Publications, Projects)
+                  <span class="required">*</span></label
+                >
+                <div
+                  class="link-group"
+                  data-link-group="supporting"
+                  data-input-name="supportingLink"
+                  data-placeholder="https://"
+                >
+                  <input
+                    id="supportingLink1"
+                    name="supportingLink1"
+                    type="url"
+                    placeholder="https://"
+                    required
+                  />
+                  <input
+                    id="supportingLink2"
+                    name="supportingLink2"
+                    type="url"
+                    placeholder="https://"
+                  />
+                </div>
+                <button
+                  class="add-link"
+                  type="button"
+                  data-add-link="supporting"
+                >
+                  <span aria-hidden="true">+</span> Add another link
+                </button>
+              </div>
+
+              <div class="field">
+                <label for="socialLink1">Social Links</label>
+                <div
+                  class="link-group"
+                  data-link-group="social"
+                  data-input-name="socialLink"
+                  data-placeholder="https://"
+                >
+                  <input
+                    id="socialLink1"
+                    name="socialLink1"
+                    type="url"
+                    placeholder="https://"
+                  />
+                  <input
+                    id="socialLink2"
+                    name="socialLink2"
+                    type="url"
+                    placeholder="https://"
+                  />
+                </div>
+                <button class="add-link" type="button" data-add-link="social">
+                  <span aria-hidden="true">+</span> Add another link
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <button class="submit-btn" type="submit">Submit Nomination</button>
+          <p class="form-status" role="status" aria-live="polite"></p>
+        </div>
+      </form>
+    </main>
+
+    <script src="../../js/main/nomination.js" defer></script>
+  </body>
+</html>

--- a/apps/frontend/styles/main/consent-request.css
+++ b/apps/frontend/styles/main/consent-request.css
@@ -1,0 +1,12 @@
+body {
+  background-color: #c5d0dd;
+}
+
+.main-header {
+  padding: var(--space-10) var(--space-4) var(--space-4) var(--space-4);
+
+  p {
+    margin: var(--space-4) 0 var(--space-9) 0;
+    max-width: 35rem;
+  }
+}

--- a/apps/frontend/styles/main/consent-request.css
+++ b/apps/frontend/styles/main/consent-request.css
@@ -10,3 +10,103 @@ body {
     max-width: 35rem;
   }
 }
+
+/* .form-section {
+  padding-top: 3rem;
+} */
+
+.form-panel {
+  gap: 3rem;
+  padding: 2rem;
+}
+
+.header-1 {
+  padding-bottom: 1.25rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.profile-upload__preview {
+  width: 6.25rem;
+  height: 6.25rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 999px;
+  }
+}
+
+.profile-upload {
+  @media (max-width: 400px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-4);
+  }
+}
+
+.form-section {
+  border-bottom: none;
+}
+
+.upload-btn {
+  display: none;
+}
+
+.actions {
+  @media (max-width: 500px) {
+    flex-direction: column-reverse;
+    align-items: stretch;
+    gap: var(--space-6);
+  }
+}
+
+.consent-actions {
+  @media (max-width: 500px) {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-1);
+  }
+}
+
+.actions .btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.625rem;
+  text-align: center;
+}
+
+.rescind {
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+}
+
+.rescind:hover {
+  background-color: #fecaca;
+  border-color: #fca5a5;
+  color: #b91c1c;
+}
+
+.consent {
+  background-color: #0ea5a4;
+  color: #ffffff;
+}
+
+.consent:hover {
+  background-color: #14b8a6;
+}
+
+.edit {
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  color: #374151;
+  padding-left: 1rem;
+}
+
+.edit:hover {
+  background-color: #cfcfcf;
+  border-color: #d1d5db;
+  color: #374151;
+}


### PR DESCRIPTION
This pull request introduces the new consent request flow for Luminary's nomination process. It adds a dedicated consent request page, associated frontend logic, and styling to support nominees reviewing and consenting to their nomination profile. The main changes are grouped below:

**Consent Request Page Implementation:**

* Added a new HTML page `consent-request.html` that presents nominees with a review of their submitted profile, supporting links, and nominator details, along with options to rescind, edit, or give consent. The form fields are initially read-only, with controls for editing and consent actions.

**Frontend Logic for Consent Form:**

* Introduced `consent-form.js` to handle interactivity on the consent request page, including panel toggling, section expansion/collapse, dynamic link fields, image preview, editing mode, and form submission with status feedback.

**Styling for Consent Request Flow:**

* Added a new stylesheet `consent-request.css` to style the consent request page, including layout, responsive actions, button states (rescind, consent, edit), and profile photo preview.


Desktop view:

<img width="2880" height="4042" alt="_home_daniel_Code_Luminary_apps_frontend_pages_main_consent-request html_ (1)" src="https://github.com/user-attachments/assets/d2e15af6-829e-4bb1-a607-90dbcbc9fa7a" />


Mobile view:
<img width="430" height="7482" alt="_home_daniel_Code_Luminary_apps_frontend_pages_main_consent-request html_(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/7202e149-45ed-44f0-9f3d-43979e539b96" />




