### PR TITLE
chore-fe: searchbar component

### DIFF
--- a/apps/web/src/components/common/search-bar.tsx
+++ b/apps/web/src/components/common/search-bar.tsx
@@ -1,0 +1,36 @@
+import { SearchBarProps } from "@/types/search.type";
+import { cn } from "@/utils/cn";
+import { Search } from "lucide-react";
+
+export function SearchBar({
+  icon,
+  type = "search",
+  placeholder = "Search...",
+  className,
+  inputClassName,
+  ...props
+}: SearchBarProps) {
+  const containerStyling = cn(
+    "flex w-full items-center gap-2 h-10 px-4 border border-border rounded-md bg-bg-surface focus-within:border-primary",
+    className,
+  );
+
+  const inputStyling = cn(
+    "w-full bg-transparent text-sm text-text-main placeholder:text-muted outline-none",
+    inputClassName,
+  );
+
+  return (
+    <label className={containerStyling}>
+      <span className="flex shrink-0 text-muted" aria-hidden="true">
+        {icon ?? <Search className="size-4" />}
+      </span>
+      <input
+        type={type}
+        placeholder={placeholder}
+        className={inputStyling}
+        {...props}
+      />
+    </label>
+  );
+}

--- a/apps/web/src/types/search.type.ts
+++ b/apps/web/src/types/search.type.ts
@@ -1,0 +1,7 @@
+import { InputHTMLAttributes, ReactNode } from "react";
+
+export interface SearchBarProps
+  extends InputHTMLAttributes<HTMLInputElement> {
+  icon?: ReactNode;
+  inputClassName?: string;
+}


### PR DESCRIPTION
This PR implements the common search bar component converted from the existing html pages

Example usage

```ts
<SearchBar className="w-40 rounded-2xl" />
```

```ts
<SearchBar value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search by name, field, organisation, country..." />
```


<img width="725" height="300" alt="image" src="https://github.com/user-attachments/assets/7e400364-1d7c-4e65-a00f-6fccae26d052" />

