### PR TITLE
Admin Nomination actions

### DIFF
--- a/apps/web/src/components/admin/columns/nomination-column.tsx
+++ b/apps/web/src/components/admin/columns/nomination-column.tsx
@@ -6,7 +6,7 @@ export interface NominationRow {
   nominee: Nominee;
   is_self_submission: boolean;
   created_at: string;
-  status: "pending" | "approved" | "rejected";
+  status: "pending" | "approved" | "rejected" | "suspended";
 }
 
 const fullName = (row: NominationRow) =>
@@ -16,6 +16,7 @@ const statusStyles: Record<NominationRow["status"], string> = {
   pending: "bg-warning/10 text-warning",
   approved: "bg-success/10 text-success",
   rejected: "bg-danger/10 text-danger",
+  suspended: "bg-muted/10 text-muted",
 };
 
 export const nominationColumns: TableColumn<NominationRow>[] = [

--- a/apps/web/src/components/admin/sections/nomination-table-section.tsx
+++ b/apps/web/src/components/admin/sections/nomination-table-section.tsx
@@ -7,15 +7,54 @@ import {
   nominationDateRangeOptions,
   nominationSortOptions,
 } from "@/data/admin";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AdminService } from "@/services/admin.service";
 import { LayoutList } from "lucide-react";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import {
   nominationColumns,
   type NominationRow,
 } from "@/components/admin/columns/nomination-column";
 
+type NominationAction = "approve" | "reject" | "suspend";
+
+const actionConfig: Record<
+  NominationAction,
+  {
+    title: string;
+    description: string;
+    confirmText: string;
+    variant: "default" | "ghost";
+    run: (id: string) => Promise<unknown>;
+  }
+> = {
+  approve: {
+    title: "Approve nomination",
+    description:
+      "This will approve the nomination and move it forward in the workflow.",
+    confirmText: "Approve",
+    variant: "default",
+    run: (id) => AdminService.ApproveNomination(id),
+  },
+  reject: {
+    title: "Reject nomination",
+    description: "This will reject the nomination. This can affect the nominee's status.",
+    confirmText: "Reject",
+    variant: "default",
+    run: (id) => AdminService.RejectNomination(id),
+  },
+  suspend: {
+    title: "Suspend nomination",
+    description: "This will suspend the nomination until it is reviewed again.",
+    confirmText: "Suspend",
+    variant: "default",
+    run: (id) => AdminService.SuspendNomination(id),
+  },
+};
+
 export function NominationTableSection() {
+  const queryClient = useQueryClient();
+
   const [filters, setFilters] = useState({
     search: "",
     sort: "nominee_name",
@@ -23,6 +62,11 @@ export function NominationTableSection() {
   });
   const debouncedSearch = useDebounce(filters.search, 300);
   const [pagination, setPagination] = useState({ page: 1, pageSize: 10 });
+
+  const [pending, setPending] = useState<{
+    id: string;
+    action: NominationAction;
+  } | null>(null);
 
   const {
     data: nominationsData,
@@ -36,9 +80,23 @@ export function NominationTableSection() {
 
   const rows = (nominationsData?.data ?? []) as NominationRow[];
 
+  const mutation = useMutation({
+    mutationFn: ({ id, action }: { id: string; action: NominationAction }) =>
+      actionConfig[action].run(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["nominations"] });
+      setPending(null);
+    },
+  });
+
   const handleView = (id: NominationRow["id"]) => {
     console.log("View nomination:", id);
   };
+
+  const requestAction = (action: NominationAction) => (id: NominationRow["id"]) =>
+    setPending({ id: String(id), action });
+
+  const active = pending ? actionConfig[pending.action] : null;
 
   return (
     <section className="w-full bg-white p-4 rounded-lg flex flex-col gap-4">
@@ -55,7 +113,11 @@ export function NominationTableSection() {
       />
 
       {isLoading && <p className="text-sm text-muted">Loading...</p>}
-      {isError && <p className="text-sm text-danger">Error: {error.message}</p>}
+      {isError && (
+        <p className="text-sm text-danger">
+          Error: {error instanceof Error ? error.message : "Failed to load nominations."}
+        </p>
+      )}
 
       {!isLoading && !isError && rows.length === 0 && <EmptyTableState />}
 
@@ -64,8 +126,26 @@ export function NominationTableSection() {
           columns={nominationColumns}
           data={rows}
           onView={handleView}
+          onApprove={requestAction("approve")}
+          onReject={requestAction("reject")}
+          onSuspend={requestAction("suspend")}
         />
       )}
+
+      <ConfirmDialog
+        open={pending !== null}
+        setOpen={(open) => {
+          if (!open) setPending(null);
+        }}
+        title={active?.title ?? ""}
+        description={active?.description}
+        confirmText={active?.confirmText}
+        variant={active?.variant}
+        loading={mutation.isPending}
+        onConfirm={() => {
+          if (pending) mutation.mutate(pending);
+        }}
+      />
     </section>
   );
 }

--- a/apps/web/src/components/common/confirm-dialog.tsx
+++ b/apps/web/src/components/common/confirm-dialog.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Modal } from "@/components/common/modal";
+import { Button } from "@/components/common/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  loading?: boolean;
+  variant?: "default" | "ghost";
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  setOpen,
+  title,
+  description,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  loading = false,
+  variant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Modal
+      open={open}
+      setOpen={setOpen}
+      title={title}
+      description={description}
+      width="sm"
+      footer={
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            text={cancelText}
+            disabled={loading}
+            onClick={() => setOpen(false)}
+            className="text-muted hover:bg-muted/10"
+          />
+          <Button
+            variant={variant}
+            text={confirmText}
+            loading={loading}
+            disabled={loading}
+            onClick={onConfirm}
+          />
+        </div>
+      }
+    >
+      <span className="sr-only">{title}</span>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/table.tsx
+++ b/apps/web/src/components/table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Eye } from "lucide-react";
+import { Ban, Check, Eye, X } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { Button } from "@/components/common/button";
 import type { DataTableProps } from "@/types/table";
@@ -9,6 +9,9 @@ export function DataTable<TRow extends { id: string | number }>({
   columns,
   data,
   onView,
+  onApprove,
+  onReject,
+  onSuspend,
   className,
   emptyMessage = "No records found.",
 }: DataTableProps<TRow>) {
@@ -73,15 +76,50 @@ export function DataTable<TRow extends { id: string | number }>({
                   );
                 })}
 
-                <td className="px-4 py-3 text-right">
-                  <Button
-                    variant="ghost"
-                    icon={<Eye size={15} />}
-                    iconPosition="left"
-                    text="View"
-                    onClick={() => onView(row.id)}
-                    className="ml-auto text-primary hover:bg-primary/10 rounded-md px-3 py-1.5 text-xs"
-                  />
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      variant="ghost"
+                      icon={<Eye size={15} />}
+                      iconPosition="left"
+                      text="View"
+                      onClick={() => onView(row.id)}
+                      className="text-primary hover:bg-primary/10 rounded-md px-3 py-1.5 text-xs"
+                    />
+
+                    {onApprove && (
+                      <Button
+                        variant="ghost"
+                        icon={<Check size={15} />}
+                        iconPosition="left"
+                        text="Approve"
+                        onClick={() => onApprove(row.id)}
+                        className="text-success hover:bg-success/10 rounded-md px-3 py-1.5 text-xs"
+                      />
+                    )}
+
+                    {onReject && (
+                      <Button
+                        variant="ghost"
+                        icon={<X size={15} />}
+                        iconPosition="left"
+                        text="Reject"
+                        onClick={() => onReject(row.id)}
+                        className="text-danger hover:bg-danger/10 rounded-md px-3 py-1.5 text-xs"
+                      />
+                    )}
+
+                    {onSuspend && (
+                      <Button
+                        variant="ghost"
+                        icon={<Ban size={15} />}
+                        iconPosition="left"
+                        text="Suspend"
+                        onClick={() => onSuspend(row.id)}
+                        className="text-warning hover:bg-warning/10 rounded-md px-3 py-1.5 text-xs"
+                      />
+                    )}
+                  </div>
                 </td>
               </tr>
             ))

--- a/apps/web/src/data/endpoints.ts
+++ b/apps/web/src/data/endpoints.ts
@@ -11,6 +11,9 @@ export const endpoints = {
   admin: {
     nominations: {
       getNominations: "/admin/nominations",
+      approve: (id: string) => `/admin/nominations/${id}/approve`,
+      reject: (id: string) => `/admin/nominations/${id}/reject`,
+      suspend: (id: string) => `/admin/nominations/${id}/suspend`,
     },
   },
 };

--- a/apps/web/src/services/admin.service.ts
+++ b/apps/web/src/services/admin.service.ts
@@ -1,23 +1,56 @@
 import { endpoints } from "@/data/endpoints";
 import { SuccessApiResponse } from "@/types/api.type";
-import { axiosGet } from "@/utils/api";
+import { axiosGet, axiosPatch } from "@/utils/api";
 import { getAuthToken } from "@/utils/auth";
+
+function authConfig() {
+  const token = getAuthToken();
+  return {
+    config: {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  };
+}
 
 export class AdminService {
   static async GetNominations() {
-    const token = getAuthToken();
-
     const response = await axiosGet(
       endpoints.admin.nominations.getNominations,
-      {
-        config: {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      },
+      authConfig(),
     );
 
     return response as SuccessApiResponse<any[]>;
+  }
+
+  static async ApproveNomination(id: string) {
+    const response = await axiosPatch(
+      endpoints.admin.nominations.approve(id),
+      undefined,
+      authConfig(),
+    );
+
+    return response as SuccessApiResponse<unknown>;
+  }
+
+  static async RejectNomination(id: string) {
+    const response = await axiosPatch(
+      endpoints.admin.nominations.reject(id),
+      undefined,
+      authConfig(),
+    );
+
+    return response as SuccessApiResponse<unknown>;
+  }
+
+  static async SuspendNomination(id: string) {
+    const response = await axiosPatch(
+      endpoints.admin.nominations.suspend(id),
+      undefined,
+      authConfig(),
+    );
+
+    return response as SuccessApiResponse<unknown>;
   }
 }

--- a/apps/web/src/types/table.ts
+++ b/apps/web/src/types/table.ts
@@ -31,6 +31,9 @@ export interface TableColumn<TRow extends { id: string | number }> {
  * @property columns      - Column definitions.
  * @property data         - Array of row objects to render.
  * @property onView       - Called with the row's `id` when the View button is clicked.
+ * @property onApprove    - Optional. Called with the row's `id` to approve it.
+ * @property onReject     - Optional. Called with the row's `id` to reject it.
+ * @property onSuspend    - Optional. Called with the row's `id` to suspend it.
  * @property className    - Optional extra class applied to the outermost wrapper.
  * @property emptyMessage - Optional message shown when `data` is empty.
  *                          Defaults to "No records found."
@@ -39,6 +42,9 @@ export interface DataTableProps<TRow extends { id: string | number }> {
   columns: TableColumn<TRow>[];
   data: TRow[];
   onView: (id: TRow["id"]) => void;
+  onApprove?: (id: TRow["id"]) => void;
+  onReject?: (id: TRow["id"]) => void;
+  onSuspend?: (id: TRow["id"]) => void;
   className?: string;
   emptyMessage?: string;
 }


### PR DESCRIPTION

Adds approve, reject, and suspend actions to the admin nominations table, each gated behind a confirmation dialog. Builds on the nominations table from #152.

**Changes**

- Added approve, reject, and suspend endpoints (parameterized by id) under admin.nominations in endpoints.ts
- Added ApproveNomination, RejectNomination, and SuspendNomination methods to AdminService, mirroring the existing GetNominations auth pattern
- Extended DataTableProps with optional onApprove/onReject/onSuspend handlers
- Rendered the action buttons in the table's actions column (ghost variant, shown only when a handler is passed)
- Wired the actions in NominationTableSection via useMutation, invalidating the nominations query on success so the list refetches
- Added a reusable ConfirmDialog wrapper around the existing Modal
- Added the suspended status to NominationRow and its badge style in nomination-column.tsx
- Hardened the table's error display against a missing error object

**Behavior**
Clicking an action opens a confirmation dialog; confirming fires the request, shows a loading state, and refetches the table on success so the status badge updates.


<img width="1145" height="498" alt="Screenshot 2026-06-27 114306" src="https://github.com/user-attachments/assets/65eedd1a-5217-49fc-a398-2449f45829e5" />

<img width="1917" height="993" alt="Screenshot 2026-06-27 114348" src="https://github.com/user-attachments/assets/5ed74134-0b84-4c0a-ae0c-f58b0fda8ba5" />
